### PR TITLE
Setup.py packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include LICENSE.text
 include README.md
-include bin/rasa

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE.text
 include README.md
+recursive-include rasa/cli/initial_project *

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # Avoids IDE errors, but actual version is read from version.py
 __version__ = None
@@ -23,6 +23,7 @@ install_requires = [
 
 setup(
     name="rasa",
+    packages=find_packages(exclude=["tests"]),
     entry_points={
         'console_scripts': ['rasa=rasa.__main__:main'],
     },

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     version=__version__,
     install_requires=install_requires,
     tests_require=tests_requires,
+    include_package_data=True,
     description="Rasa Stack - A package which includes Rasa Core and Rasa NLU",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
That's supposed to fix the `Module not found error` when installing the package from pypi: Solution taken from: https://stackoverflow.com/questions/21028165/setuptools-console-script-entry-point-not-found-with-install-but-its-found-with

~UPDATE: Not ready to merge, we also have to include the initial project stuff~ fixed

test with `python setup.py install`